### PR TITLE
Export API host from parent process to child process.

### DIFF
--- a/openwhisk/actionProxy.go
+++ b/openwhisk/actionProxy.go
@@ -71,6 +71,7 @@ func NewActionProxy(baseDir string, compiler string, outFile *os.File, errFile *
 
 //SetEnv sets the environment
 func (ap *ActionProxy) SetEnv(env map[string]interface{}) {
+	ap.env["__OW_API_HOST"] = os.Getenv("__OW_API_HOST")
 	for k, v := range env {
 		s, ok := v.(string)
 		if ok {


### PR DESCRIPTION
See https://github.com/apache/openwhisk/pull/4765 for some background. The tests in this repo fail when the test is fixed.
<img width="1299" alt="Screen Shot 2019-12-14 at 12 17 56 PM" src="https://user-images.githubusercontent.com/4959922/70852137-ea551580-1e6b-11ea-8252-89a457833708.png">

With this patch, now the tests pass.
<img width="442" alt="Screen Shot 2019-12-14 at 12 16 41 PM" src="https://user-images.githubusercontent.com/4959922/70852143-f04af680-1e6b-11ea-9ad7-88a16f81909e.png">

