### PR TITLE
Update to go 1.12.17, include secuity fixes with every build.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@
 #
 -->
 # 1.16.0 (next release)
+- upgraded to go 1.12.17
+- add 'apt-get upgrade' to the image build to get latest security fixes during each build, for the case the base images are not updated frequently
 - added OW_WAIT_FOR_ACK such at if true, the proxy waits for an acknowledgement from the action on startup
 - added OW_EXECUTION_ENV to validate the execution environment before starting an action
 - write compilation logs to standard out

--- a/golang1.11/CHANGELOG.md
+++ b/golang1.11/CHANGELOG.md
@@ -19,6 +19,6 @@
 
 # Go 1.11 OpenWhisk Runtime Container
 
-## Apache 1.13.0-incubating (next release)
-- Initial version
-- Go 1.11.6
+## Apache 1.16 (next release)
+Changes:
+- Adding Go 1.11.13

--- a/golang1.11/Dockerfile
+++ b/golang1.11/Dockerfile
@@ -15,19 +15,18 @@
 # limitations under the License.
 #
 FROM golang:1.11.13
-RUN echo "deb http://deb.debian.org/debian stretch-backports main contrib non-free" \
-     >>/etc/apt/sources.list &&\
-    apt-get update && apt-get install -y \
-     curl \
-     jq \
-     git &&\
-    apt-get -y install \
-     librdkafka1=0.11.6-1~bpo9+1 \
-     librdkafka++1=0.11.6-1~bpo9+1 && \
-    apt-get -y install \
-     librdkafka-dev=0.11.6-1~bpo9+1 && \
-    rm -rf /var/lib/apt/lists/*
-RUN mkdir /action
+RUN echo "deb http://deb.debian.org/debian stretch-backports main contrib non-free" >>/etc/apt/sources.list \
+    && apt-get update \
+    && apt-get -y --no-install-recommends upgrade \
+    && apt-get -y --no-install-recommends install \
+                        curl jq git \
+                        librdkafka1=0.11.6-1~bpo9+1 \
+                        librdkafka++1=0.11.6-1~bpo9+1 \
+                        librdkafka-dev=0.11.6-1~bpo9+1 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir /action
+
 WORKDIR /action
 ADD proxy /bin/proxy
 ADD gobuild.py /bin/compile

--- a/golang1.12/CHANGELOG.md
+++ b/golang1.12/CHANGELOG.md
@@ -1,3 +1,4 @@
+<!--
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -14,22 +15,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM golang:1.12.17
-RUN echo "deb http://deb.debian.org/debian stretch-backports main contrib non-free" >>/etc/apt/sources.list \
-    && apt-get update \
-    && apt-get -y --no-install-recommends upgrade \
-    && apt-get -y --no-install-recommends install \
-                        curl jq git \
-                        librdkafka1=0.11.6-1~bpo9+1 \
-                        librdkafka++1=0.11.6-1~bpo9+1 \
-                        librdkafka-dev=0.11.6-1~bpo9+1 \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    && mkdir /action
+-->
 
-WORKDIR /action
-ADD proxy /bin/proxy
-ADD gobuild.py /bin/compile
-ADD gobuild.py.launcher.go /bin/compile.launcher.go
-ENV OW_COMPILER=/bin/compile
-ENTRYPOINT [ "/bin/proxy" ]
+# Go 1.12 OpenWhisk Runtime Container
+
+## Apache 1.16 (next release)
+Changes:
+- Adding Go 1.12.17


### PR DESCRIPTION
  - Updated golang1.12 to go 1.12.17.
  - Add 'apt-get upgrade' to the image builds to include security fixes with each build in case the used base image is not updated frequently.
    In case the base image is updated frequently the 'apt-get upgrade' is a no operation. If not it will catch the security updates available since the last update of the base image.
    This change was not done for the actionloop/Dockerfile as this directly points to the ubuntu base image (ubuntu:xenial) which contains the security fixes.