### PR TITLE
Upgrade golang version to 1.13 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@
 sudo: required
 language: go
 go:
-  - "1.12.9"
+  - "1.13.14"
 services:
   - docker
 notifications:

--- a/common/gobuild.py
+++ b/common/gobuild.py
@@ -56,7 +56,8 @@ def build(parent, source_dir, target):
     env = {
       "PATH": os.environ["PATH"],
       "GOPATH": os.path.abspath(parent),
-      "GOCACHE": "/tmp"
+      "GOCACHE": "/tmp",
+      "GO111MODULE": "off"
     }
     if os.path.isdir("%s/main" % source_dir):
         source_dir += "/main"


### PR DESCRIPTION
Seems github.com/stretchr/testify/assert is not compatible with go 1.12