### PR TITLE
Build in Travis with go 1.15.13 which is a supported version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@
 sudo: required
 language: go
 go:
-  - "1.13.14"
+  - "1.15.13"
 services:
   - docker
 


### PR DESCRIPTION
Changes Travis to use Go 1.15.13 to be on a supported version