### PR TITLE
Extend `proxy -version` to also show the go runtime version.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@
 # 1.17.1
 - support for zipping and unzipping symbolic links (required to support virtualenvs)
 - go 1.15 runtime upgraded to 1.15.13
+- extend `proxy -version` to also show the go version the proxy.go was compiled with (makes it easier to check if go security updates need to be applied)
 
 # 1.17.0
 - go 1.15 runtime upgraded to 1.15.7

--- a/main/proxy.go
+++ b/main/proxy.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"runtime"
 
 	"github.com/apache/openwhisk-runtime-go/openwhisk"
 )
@@ -49,7 +50,7 @@ func main() {
 
 	// show version number
 	if *version {
-		fmt.Printf("OpenWhisk ActionLoop Proxy v%s\n", openwhisk.Version)
+		fmt.Printf("OpenWhisk ActionLoop Proxy v%s, built with %s\n", openwhisk.Version, runtime.Version())
 		return
 	}
 


### PR DESCRIPTION
- Extend `proxy -version` to also show the go version the proxy.go was compiled with (makes it easier to check if go security updates need to be applied).