### PR TITLE
Automatically include go1.15.x and go1.16.x security fixes during build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@
 sudo: required
 language: go
 go:
-  - "1.16.6"
+  - "1.16.x"   # Do not fix the patch level to automatically get security fixes.
 services:
   - docker
 

--- a/golang1.15/Dockerfile
+++ b/golang1.15/Dockerfile
@@ -14,7 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM golang:1.15.14
+
+# Do not fix the patch level for golang:1.15 to automatically get security fixes.
+FROM golang:1.15
+
 RUN echo "deb http://deb.debian.org/debian buster-backports main contrib non-free" \
      >>/etc/apt/sources.list &&\
     echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections &&\

--- a/golang1.16/Dockerfile
+++ b/golang1.16/Dockerfile
@@ -14,7 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM golang:1.16.6
+
+# Do not fix the patch level for golang:1.16 to automatically get security fixes.
+FROM golang:1.16-buster
+
 RUN echo "deb http://deb.debian.org/debian buster-backports main contrib non-free" \
      >>/etc/apt/sources.list &&\
     echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections &&\


### PR DESCRIPTION
- Relax the builds of the go1.15 and go1.16 runtimes to automatically use the latest go patch level instead of using fixed ones.
  This allows to automatically include the latest security fixes for these runtimes. Up to now this always required a change and therefore a PR to be processed.
  Relaxing this allows these runtimes to automatically stay actual without further effort.
  This is basically the same behavior as used for example for the python:3.7 (https://github.com/apache/openwhisk-runtime-python/blob/16c608107beee74078eaf47c82a1db4e24602b38/core/python3Action/Dockerfile#L19) or the swift:5.3 (https://github.com/apache/openwhisk-runtime-swift/blob/60fb30cbd17f967736b4309d17f706ff26279e2f/core/swift53Action/Dockerfile#L19) runtimes.

- For the go 1.16 image it was necessary to use `golang:1.16-buster`. Reason is that `golang:1.16` is bullseye based while the formerly used `golang:1.16.6` was buster based.