### PR TITLE
Python 2 and 3 support for go 1.17 runtime

### DIFF
--- a/golang1.17/bin/compile
+++ b/golang1.17/bin/compile
@@ -72,7 +72,7 @@ def build(source_dir, target_dir):
     parent = dirname(source_dir)
     target = os.path.abspath("%s/exec" % target_dir)
     if os.environ.get("__OW_EXECUTION_ENV"):
-      write_file("%s.env" % target, os.environ["__OW_EXECUTION_ENV"])
+      write_file("%s.env" % target, str.encode(os.environ["__OW_EXECUTION_ENV"]))
 
     env = {
       "GOROOT": "/usr/local/go",


### PR DESCRIPTION
The compile script for golang 1.17 actions will now work with python 3 as well as continue to work with Python 2