### PR TITLE
Set github.com/go-delve/delve/cmd/dlv to 1.8.1 as temporary fix to ge…

### DIFF
--- a/golang1.15/Dockerfile
+++ b/golang1.15/Dockerfile
@@ -18,6 +18,8 @@
 # Do not fix the patch level for golang:1.15 to automatically get security fixes.
 FROM golang:1.15
 
+ENV GO111MODULE=on
+
 RUN echo "deb http://deb.debian.org/debian buster-backports main contrib non-free" \
      >>/etc/apt/sources.list &&\
     echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections &&\
@@ -37,7 +39,7 @@ RUN echo "deb http://deb.debian.org/debian buster-backports main contrib non-fre
      librdkafka-dev=0.11.6-1.1 &&\
     # Cleanup apt data, we do not need them later on.
     apt-get clean && rm -rf /var/lib/apt/lists/* &&\
-    go get -u github.com/go-delve/delve/cmd/dlv &&\
+    go get -u github.com/go-delve/delve/cmd/dlv@v1.8.1 &&\
     mkdir /action
 
 WORKDIR /action

--- a/golang1.16/Dockerfile
+++ b/golang1.16/Dockerfile
@@ -18,6 +18,8 @@
 # Do not fix the patch level for golang:1.16 to automatically get security fixes.
 FROM golang:1.16-buster
 
+ENV GO111MODULE=on
+
 RUN echo "deb http://deb.debian.org/debian buster-backports main contrib non-free" \
      >>/etc/apt/sources.list &&\
     echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections &&\
@@ -37,7 +39,7 @@ RUN echo "deb http://deb.debian.org/debian buster-backports main contrib non-fre
      librdkafka-dev=0.11.6-1.1 &&\
     # Cleanup apt data, we do not need them later on.
     apt-get clean && rm -rf /var/lib/apt/lists/* &&\
-    go get -u github.com/go-delve/delve/cmd/dlv &&\
+    go get -u github.com/go-delve/delve/cmd/dlv@v1.8.1 &&\
     mkdir /action
 
 WORKDIR /action

--- a/golang1.17/Dockerfile
+++ b/golang1.17/Dockerfile
@@ -37,7 +37,7 @@ RUN echo "deb http://deb.debian.org/debian buster-backports main contrib non-fre
      librdkafka-dev=0.11.6-1.1 &&\
     # Cleanup apt data, we do not need them later on.
     apt-get clean && rm -rf /var/lib/apt/lists/* &&\
-    go get -u github.com/go-delve/delve/cmd/dlv &&\
+    go get -u github.com/go-delve/delve/cmd/dlv@v1.8.1 &&\
     mkdir /action
 
 WORKDIR /action


### PR DESCRIPTION
Set github.com/go-delve/delve/cmd/dlv to 1.8.1 as temporary fix to get the build to work again until latest version works again