### PR TITLE
Update to recent travis build vm to unblock build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,10 @@
 #
 
 sudo: required
+dist: focal
 language: go
 go:
-  - "1.16.x"   # Do not fix the patch level to automatically get security fixes.
+  - "1.19.x"   # Do not fix the patch level to automatically get security fixes.
 services:
   - docker
 

--- a/openwhisk/_test/pysample/lib/exec.py
+++ b/openwhisk/_test/pysample/lib/exec.py
@@ -33,5 +33,5 @@ while True:
             payload = args["value"]
         res = main(payload)
         out.write(json.dumps(res, ensure_ascii=False).encode('utf-8'))
-        out.write("\n")
+        out.write(b"\n")
         out.flush()


### PR DESCRIPTION
Current travis build VM is still using xenial (16.04) as base. Updates to this image caused build breaks. 
Updating to a more recent build environment (same as for apache/openwhisk -> https://github.com/apache/openwhisk/blob/master/.travis.yml) should reduce these from happening.

Also need to update to a current go version on the build environment as only go 1.18 and go 1.19 are actually supported.