### PR TITLE
Add tar.gz support to the go Proxy

### DIFF
--- a/openwhisk/extractor.go
+++ b/openwhisk/extractor.go
@@ -64,6 +64,17 @@ func (ap *ActionProxy) ExtractAction(buf *[]byte, suffix string) (string, error)
 		}
 		Debug("Extract Action, assuming a zip")
 		return file, Unzip(*buf, newDir)
+
+	} else if IsTarGz(*buf) {
+		jar := os.Getenv("OW_SAVE_JAR")
+		if jar != "" {
+			jarFile := newDir + "/" + jar
+			Debug("Extract Action, checking if it is a jar first")
+			return jarFile, UnzipOrSaveJar(*buf, newDir, jarFile)
+		}
+
+		Debug("Extract Action, assuming a zip")
+		return file, UnTar(*buf, newDir)
 	}
 	return file, ioutil.WriteFile(file, *buf, 0755)
 }

--- a/openwhisk/filetype.go
+++ b/openwhisk/filetype.go
@@ -65,3 +65,13 @@ func IsZip(buf []byte) bool {
 		(buf[2] == 0x3 || buf[2] == 0x5 || buf[2] == 0x7) &&
 		(buf[3] == 0x4 || buf[3] == 0x6 || buf[3] == 0x8)
 }
+
+// IsTarGz checks if the given file is a valid tar.gz file
+func IsTarGz(buf []byte) bool {
+	// Magic number: The first two bytes are fixed (0x1f and 0x8b), which represent the magic number of a gzip file.
+	// Compression method: The third byte indicates the compression method used. For gzip files, this is always  (deflate).
+	return len(buf) > 3 &&
+		buf[0] == 0x1f &&
+		buf[1] == 0x8b &&
+		buf[2] == 0x08
+}

--- a/openwhisk/tar.go
+++ b/openwhisk/tar.go
@@ -1,0 +1,91 @@
+package openwhisk
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+func openTar(src []byte) (*tar.Reader, error) {
+	// Create a new bytes.Reader from the input byte slice
+	reader := bytes.NewReader(src)
+
+	// Create a new gzip.Reader from the bytes.Reader
+	gzipReader, err := gzip.NewReader(reader)
+	if err != nil {
+		return nil, err
+	}
+	defer gzipReader.Close()
+
+	// Create a new tar.Reader from the gzip.Reader
+	tarReader := tar.NewReader(gzipReader)
+
+	return tarReader, nil
+}
+
+func UnTar(src []byte, dest string) error {
+	r, err := openTar(src)
+	if err != nil {
+		return err
+	}
+	Debug("open Tar")
+	os.MkdirAll(dest, 0755)
+	for {
+		header, err := r.Next()
+		fmt.Println("Err", err)
+		switch {
+
+		// if no more files are found return
+		case err == io.EOF:
+			return nil
+
+		// return any other error
+		case err != nil:
+			return err
+
+		// if the header is nil, just skip it (not sure how this happens)
+		case header == nil:
+			continue
+		}
+
+		// the target location where the dir/file should be created
+		target := filepath.Join(dest, header.Name)
+		// isLink := header.FileInfo().Mode()&os.ModeSymlink == os.ModeSymlink
+
+		// the following switch could also be done using fi.Mode(), not sure if there
+		// a benefit of using one vs. the other.
+		// fi := header.FileInfo()
+
+		// check the file type
+		switch header.Typeflag {
+
+		// if its a dir and it doesn't exist create it
+		case tar.TypeDir:
+			if _, err := os.Stat(target); err != nil {
+				if err := os.MkdirAll(target, 0755); err != nil {
+					return err
+				}
+			}
+
+		// if it's a file create it
+		case tar.TypeReg:
+			f, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
+			if err != nil {
+				return err
+			}
+
+			// copy over contents
+			if _, err := io.Copy(f, r); err != nil {
+				return err
+			}
+
+			// manually close here after each file operation; defering would cause each file close
+			// to wait until all operations have completed.
+			f.Close()
+		}
+	}
+}


### PR DESCRIPTION
This new feature will allow for more versatile deployment packages and greater flexibility in handling compressed files. Giving an alternative to zip files.

this feature does not impact the current functionality of the go Proxy