### PR TITLE
Remove dependency on obsolete buster-backports respository.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,9 @@
 # limitations under the License.
 #
 -->
+# Next Release
+- Remove obsolete buster-backports repository from build.
+
 # 1.24.0
 - Add support for golang 1.22 (#195)
 - Drop support for golang 1.19 (#197)

--- a/golang1.20/Dockerfile
+++ b/golang1.20/Dockerfile
@@ -18,9 +18,7 @@
 # Do not fix the patch level for golang:1.20 to automatically get security fixes.
 FROM golang:1.20-bullseye
 
-RUN echo "deb http://deb.debian.org/debian buster-backports main contrib non-free" \
-     >>/etc/apt/sources.list &&\
-    echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections &&\
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections &&\
     apt-get update &&\
     # Upgrade installed packages to get latest security fixes if the base image does not contain them already.
     apt-get upgrade -y --no-install-recommends &&\

--- a/golang1.21/Dockerfile
+++ b/golang1.21/Dockerfile
@@ -18,9 +18,7 @@
 # Do not fix the patch level for golang:1.21 to automatically get security fixes.
 FROM golang:1.21-bookworm
 
-RUN echo "deb http://deb.debian.org/debian buster-backports main contrib non-free" \
-     >>/etc/apt/sources.list &&\
-    echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections &&\
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections &&\
     apt-get update &&\
     # Upgrade installed packages to get latest security fixes if the base image does not contain them already.
     apt-get upgrade -y --no-install-recommends &&\

--- a/golang1.22/Dockerfile
+++ b/golang1.22/Dockerfile
@@ -18,9 +18,7 @@
 # Do not fix the patch level for golang:1.22 to automatically get security fixes.
 FROM golang:1.22-bookworm
 
-RUN echo "deb http://deb.debian.org/debian buster-backports main contrib non-free" \
-     >>/etc/apt/sources.list &&\
-    echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections &&\
+RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections &&\
     apt-get update &&\
     # Upgrade installed packages to get latest security fixes if the base image does not contain them already.
     apt-get upgrade -y --no-install-recommends &&\


### PR DESCRIPTION
The support for the buster-backports repository is now dropped by debian. Options are 
- to jump to a newer backports repository
- or to remove this dependency as it seems it is currently not used.

For now we will remove this dependency (reduce complexity).